### PR TITLE
Fix token placement positioning bug

### DIFF
--- a/app/hooks/useDragAndDrop.ts
+++ b/app/hooks/useDragAndDrop.ts
@@ -72,8 +72,8 @@ export function useDragAndDrop(initialPositions: TokenPositions): DragAndDropSta
         const circleSize = TOKEN_SIZE / GRID_SIZE
         
         // Clamp the position to ensure the circle stays within bounds
-        const clampedX = Math.max(0, Math.min(1 - circleSize, newNormalizedX))
-        const clampedY = Math.max(0, Math.min(1 - circleSize, newNormalizedY))
+        const clampedX = Math.max(0, Math.min(1, newNormalizedX))
+        const clampedY = Math.max(0, Math.min(1, newNormalizedY))
         
         setPositions(prev => ({
           ...prev,
@@ -107,4 +107,4 @@ export function useDragAndDrop(initialPositions: TokenPositions): DragAndDropSta
     handleDragCancel,
     updatePosition
   }
-} 
+}  


### PR DESCRIPTION
# Fix token placement positioning bug

## Summary
Fixes a bug where tokens would appear in different positions after saving compared to where users dragged them during placement. The issue was in the boundary clamping logic in `useDragAndDrop.ts` that restricted the draggable area to `1 - circleSize` but the display logic didn't apply the same restriction, creating a coordinate system mismatch.

**Root Cause**: The boundary clamping used `Math.min(1 - circleSize, newNormalizedX)` which subtracted the token size from the maximum bounds during drag operations. However, the display logic in `DraggableToken.tsx` doesn't apply this same restriction, causing tokens to appear in different positions after the drag → save → display cycle.

**Fix**: Changed the clamping to `Math.min(1, newNormalizedX)` to align the coordinate systems throughout the entire pipeline.

## Review & Testing Checklist for Human
**⚠️ Manual testing required - automated testing was blocked by signup form validation issues**

- [ ] **Test complete placement workflow end-to-end**: Sign up → create/join group → place yourself → place others → view results. Verify tokens appear exactly where they were dragged, especially near grid edges
- [ ] **Check boundary behavior**: Ensure tokens don't appear partially off-screen or get clipped after the coordinate clamping change
- [ ] **Test edge cases**: Drag tokens to the very edges and corners of the grid where the old `1 - circleSize` clamping would have had the most impact
- [ ] **Verify coordinate pipeline**: Confirm the coordinate conversion works correctly across `useDragAndDrop.ts` → `useGroupWorkflow.ts` → database → display via `DraggableToken.tsx`

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    DragEvents["Drag Events<br/>(pixel coordinates)"] --> useDragAndDrop["app/hooks/useDragAndDrop.ts<br/>BOUNDARY CLAMPING"]:::major-edit
    useDragAndDrop --> useGroupWorkflow["app/hooks/useGroupWorkflow.ts<br/>Save to Database<br/>(normalized → percentage)"]:::context
    useGroupWorkflow --> Database["Supabase Database<br/>(percentage coordinates)"]:::context
    Database --> useGroupWorkflow
    useGroupWorkflow --> DraggableToken["app/components/DraggableToken.tsx<br/>Display Logic<br/>(percentage → pixels)"]:::context
    DraggableToken --> TokenGrid["app/components/TokenGrid.tsx<br/>Grid Container"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- **Link to Devin run**: https://app.devin.ai/sessions/4f69ac84cb0048a59de5e25bdfc60c07
- **Requested by**: @Nils-Forstall
- **Build status**: ✅ `npm run build` passes successfully
- **Testing limitation**: Unable to complete full end-to-end testing due to signup form email validation preventing account creation
- **Constants**: `TOKEN_SIZE = 35`, `GRID_SIZE = 300`, so `circleSize = 35/300 ≈ 0.117` was being subtracted from max bounds
- **Risk**: This change removes a boundary restriction that may have been intentional for UX reasons - please verify the new behavior meets design requirements